### PR TITLE
Add Docker Scout to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can also message Patrick Garrity on Linkedin here: https://www.linkedin.com/
 | Dazz | Dazz Unified Remediation Platform | https://www.dazz.io/platform |
 | Denexus | OT Cyber Risk Quantification | https://www.denexus.io/products/derisk/industrial
 | DevOcean | Low-Touch Remediation Platform | https://www.devocean.security/blog/epss-everything-you-need-to-know |
+| Docker Scout | Solution for proactively enhancing your software supply chain security | https://www.docker.com/products/docker-scout/ |
 | EdgeBit | EdgeBit Security Platform | https://edgebit.io/docs/0.x/investigate-epss/ |
 | Edgescan | Risk-Based Vulnerability Management Solution | https://www.edgescan.com/solutions/vulnerability-management/ |
 | Endor Labs | Endor Labs | https://www.endorlabs.com/blog/cve-vulnerability-epss-ssvc-reachability-vex |


### PR DESCRIPTION
I'd like to include Docker Scout to the list of EPSS vendors. 

EPSS score and percentile are shown in the Docker Scout CLI since v1.6.0 as part of `docker scout cves <image> --epss` (see [release notes](https://github.com/docker/scout-cli/releases/tag/v1.6.0)).

![image](https://github.com/FIRSTdotorg/epss-vendors/assets/15997951/d34f69da-336f-4cbe-a38f-18a946f46d34)

cc @cdupuis