### PR TITLE
Add Semgrep to vendor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ attributes:
 
 A list of vendors with products who support EPSS in their products.
 
-In order to be added to this list, please submit a pull request with a link to evidence that your product supports EPSS. 
+In order to be added to this list, please [submit a pull request](https://github.com/FIRSTdotorg/epss-vendors) with a link to evidence that your product supports EPSS. 
 You can also message Patrick Garrity on Linkedin here: https://www.linkedin.com/in/patrickmgarrity/
 
 | Vendor | Product | Link |
@@ -95,6 +95,7 @@ You can also message Patrick Garrity on Linkedin here: https://www.linkedin.com/
 | Securin | Vulnerability Intelligence | https://www.securin.io/vulnerability-intelligence/ |
 | SecurityScorecard | CVE Details | https://www.cvedetails.com/epss/epss-score-history.html |
 | Seemplicity | Seemplicity | https://seemplicity.io/different-approaches-for-vulnerability-prioritization/ |
+| Semgrep | Semgrep AppSec Platform | https://semgrep.dev/ |
 | ServiceNow | ServiceNow Vulnerability Response | https://docs.servicenow.com/bundle/vancouver-security-management/page/product/secops-integration-vr/epss/concept/epss-vr-integration-overview.html |
 | Shield Cyber | Attacker-centric Exposure Management | https://www.shieldcyber.io/ |
 | Shodan | CVEDB API | https://cvedb.shodan.io/ |


### PR DESCRIPTION
Evidence:
<img width="912" alt="Screenshot 2024-08-15 at 3 20 59 PM" src="https://github.com/user-attachments/assets/5d514ae2-c0ca-4741-85e2-a859a6e5f195">

I also added a link to this repo since it wasn't clear to me from the [Who is using EPSS](https://www.first.org/epss/who_is_using/) page where I should make the PR. I ended up searching github for one of the vendor URLs 😅