### PR TITLE
add fluid attacks to EPSS vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can also message Patrick Garrity on Linkedin here: https://www.linkedin.com/
 | FOSSA | The Modern Open Source Risk Platform | https://fossa.com/blog/understanding-using-epss-scoring-system/ |
 | Flashpoint | Flashpoint VulnDB | https://flashpoint.io/resources/datasheets/vulndb-ransomware-and-exploit-prediction-model/|
 | Fleet | Open-source device management | https://fleetdm.com/upgrade |
+| Fluid Attacks | Fluid Attacks | https://fluidattacks.com/ |
 | ForeScout | Risk and Exposure Management | https://www.forescout.com/products/rem/ |
 | Fortinet | Forinet DAST | https://docs.fortinet.com/document/fortidast/23.3.0/user-guide/476620/vulnerabilities |
 | FortMesa | Riskchain VM | https://land.fortmesa.com/vulnerability-management-101 |


### PR DESCRIPTION
Add Fluid Attacks as EPSS vendor:

![image](https://github.com/user-attachments/assets/431d8afc-f064-4dd3-957e-a6119879fd45)

https://help.fluidattacks.com/portal/en/kb/articles/analyze-your-supply-chain-security#All_packages:~:text=that%20dependency%20version.-,%25%20EPSS%3A%C2%A0The%20likelihood%20of%20the%20vulnerability%20being%20exploited%20compared%20to%20that%20of%20all%20other%20known%20vulnerabilities,-%27EPSS%27%20stands%20for
