### PR TITLE
Add Dependabot to EPSS supported vendor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can also message Patrick Garrity on Linkedin here: https://www.linkedin.com/
 | Fortinet | Forinet DAST | https://docs.fortinet.com/document/fortidast/23.3.0/user-guide/476620/vulnerabilities |
 | FortMesa | Riskchain VM | https://land.fortmesa.com/vulnerability-management-101 |
 | Finite State | Finite State Platform | https://finitestate.io/products/finite-state-platform/ |
+| GitHub | Dependabot | https://docs.github.com/en/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts |
 | Github Advisory Database | https://github.blog/changelog/2024-10-10-epss-scores-in-the-github-advisory-database/ |
 | HackerOne | CVE Discovery | https://hackerone.com/hacktivity/cve_discovery |
 | Hackuity | Risk-Based Vulnerability Management | https://www.hackuity.io/ |


### PR DESCRIPTION
evidence: https://github.blog/changelog/2025-02-19-dependabot-helps-users-focus-on-the-most-important-alerts-by-including-epss-scores-that-indicate-likelihood-of-exploitation-now-generally-available/