### PR TITLE
Add VulnDex to EPSS supported vendor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can also message Patrick Garrity on Linkedin here: https://www.linkedin.com/
 | HackerOne | CVE Discovery | https://hackerone.com/hacktivity/cve_discovery |
 | Hackuity | Risk-Based Vulnerability Management | https://www.hackuity.io/ |
 | IBM Security | | |
+| Kerzinger | VulnDex | https://vulndex.at/ |
 | Keysight | Keysight IoT Security Assessment | https://www.keysight.com/be/en/products/network-security/iot-security-assessment.html |
 | Kodem | Kodem Security | https://www.kodemsecurity.com/ |
 | Kondukto | Kondukto ASPM Platform | https://kondukto.io/ |


### PR DESCRIPTION
VulnDex has been added to the list.

Evidence:
![image](https://github.com/user-attachments/assets/2c5c3f79-cd5d-49ec-902e-b96799358b33)

https://vulndex.at/cve/CVE-2025-2803 